### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 MCP Server for Ethereum Name Service (ENS), enabling Claude to interact with the ENS system to resolve names, check availability, retrieve records, and more.
 
 npm package: https://www.npmjs.com/package/mcp-server-ens
+
+<a href="https://glama.ai/mcp/servers/@JustaName-id/ens-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JustaName-id/ens-mcp-server/badge" alt="ENS Server MCP server" />
+</a>
+
 ## Tools
 
 ### resolve-name


### PR DESCRIPTION
This PR adds a badge for the [ENS MCP Server](https://glama.ai/mcp/servers/@JustaName-id/ens-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@JustaName-id/ens-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JustaName-id/ens-mcp-server/badge" alt="ENS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.